### PR TITLE
@types/react-router: Adds support for typing the state on <Redirect />

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -54,15 +54,15 @@ export interface PromptProps {
 }
 export class Prompt extends React.Component<PromptProps, any> { }
 
-export interface RedirectProps {
-  to: H.LocationDescriptor;
+export interface RedirectProps<LocationState = any> {
+  to: H.LocationDescriptor<LocationState>;
   push?: boolean;
   from?: string;
   path?: string;
   exact?: boolean;
   strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps, any> { }
+export class Redirect<LocationState = any> extends React.Component<RedirectProps<LocationState>, any> { }
 
 export interface StaticContext {
   statusCode?: number;


### PR DESCRIPTION
The current implementation of `<Redirect />` doesn't support any generic to type its state, so there's no way to validate it.

Imagine the following route:

```
interface MyAwesomeRouteState {
 foo: boolean;
}

<Redirect to={{
   pathname: "/my-awesome-route",
   state: {
      foo: true,
      bar: "this should fail, but it won't :'("
   }
}} />
```

With these changes, validating the state becomes possible:

```
interface MyAwesomeRouteState {
 foo: boolean;
}

<Redirect<MyAwesomeRouteState> to={{
   pathname: "/my-awesome-route",
   state: {
      foo: true,
      bar: "this will now fail :)"
   }
}} />
```

:tada:
